### PR TITLE
Use binary search instead of line search. And Fix '保留地址' issue.

### DIFF
--- a/IP/ip.py
+++ b/IP/ip.py
@@ -82,7 +82,7 @@ class IPv4Database(object):
         data_length = 0
         data_pos = 0
 
-        lo, hi = 0, (self._offset - offset) / 8
+        lo, hi = 0, (self._offset - offset) // 8
 
         while lo < hi:
             mid = (lo + hi) // 2


### PR DESCRIPTION
hi, folks:
    I use binary search to replace line search. And I do a simple benchmark. The total query time down to 3.5s from 20s. 
    The benchmark script like this:

<pre>
import time
from IP import IPv4Database

db = IPv4Database()


st = time.time()
for i in xrange(0, 256*256*256*256, 17173):
    ip = [0, 0, 0, 0]
    cnt = 0
    while i > 0:
        ip[cnt] = i % 256
        i = i / 256
        cnt += 1
    db._lookup_ipv4('.'.join(map(str, ip)))
en = time.time()

print en - st
</pre>


And I found a issue. Some IP should be mapped to '保留地址', not 'None', like '0.42.134.0'. 
